### PR TITLE
fix: remove erroneous sigmoid layer in HRStreamGenerator (only present in stochastic branch)

### DIFF
--- a/ClimatExML/models.py
+++ b/ClimatExML/models.py
@@ -316,7 +316,6 @@ class HRStreamGenerator(nn.Module):
         outf = self.HR_pre(x_fine)  ## HR branch
         out = torch.cat((outc, outf), 1)  ##combine
         out = self.conv3(out)
-        out = self.sig(out)
 
         return out
 


### PR DESCRIPTION
The sigmoid layer that was removed from the main branch in the HRStreamGenerator is still present in the stochastic branch as far as I can tell -- this removes it as it causes problems. (Specifically, removes the out = self.sig(out) on line 319 of models.py.)