### PR TITLE
Add `BaseSuperResolutionTrainer` and initial `CNNTrainer` implementation

### DIFF
--- a/ClimatExML/base_trainer.py
+++ b/ClimatExML/base_trainer.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+import lightning as pl
+
+class BaseSuperResolutionTrainer(pl.LightningModule, ABC):
+    @abstractmethod
+    def training_step(self, batch, batch_idx):
+        pass
+
+    @abstractmethod
+    def validation_step(self, batch, batch_idx):
+        pass
+
+    @abstractmethod
+    def configure_optimizers(self):
+        pass

--- a/ClimatExML/base_trainer.py
+++ b/ClimatExML/base_trainer.py
@@ -2,6 +2,9 @@ from abc import ABC, abstractmethod
 import lightning as pl
 
 class BaseSuperResolutionTrainer(pl.LightningModule, ABC):
+    def __init__(self):
+        super().__init__()
+    
     @abstractmethod
     def training_step(self, batch, batch_idx):
         pass

--- a/ClimatExML/cnn.py
+++ b/ClimatExML/cnn.py
@@ -1,0 +1,77 @@
+import torch
+import torch.nn.functional as F
+import lightning as pl
+
+from torchmetrics.functional import mean_squared_error
+from ClimatExML.models import HRStreamGenerator
+from ClimatExML.trainer_utils import configure_figure
+from ClimatExML.base_trainer import BaseSuperResolutionTrainer
+
+
+class CNNTrainer(BaseSuperResolutionTrainer):
+    def __init__(
+        self,
+        tracking,
+        hardware,
+        hyperparameters,
+        invariant,
+        **kwargs,
+    ):
+        super().__init__()
+        self.save_hyperparameters()
+
+        self.log_every_n_steps = tracking.log_every_n_steps
+        self.validation_log_every_n_steps = tracking.validation_log_every_n_steps
+        self.save_dir = tracking.save_dir
+        self.experiment_name = tracking.experiment_name
+
+        self.learning_rate = hyperparameters.learning_rate
+        self.lr_shape = invariant.lr_shape
+        self.hr_shape = invariant.hr_shape
+        self.hr_invariant_shape = invariant.hr_invariant_shape
+
+        n_covariates, lr_dim, _ = self.lr_shape
+        n_predictands, hr_dim, _ = self.hr_shape
+        n_hr_covariates = self.hr_invariant_shape[0]
+
+        self.G = HRStreamGenerator(
+            noise=False,
+            filters=64,
+            fine_dims=hr_dim,
+            channels=n_covariates,
+            channels_hr_cov=n_hr_covariates,
+            n_predictands=n_predictands,
+        )
+
+    def unpack_batch(self, batch):
+        lr, hr, hr_cov = batch
+        return lr.float(), hr.float(), hr_cov.float()
+
+    def training_step(self, batch, batch_idx):
+        lr, hr, hr_cov = self.unpack_batch(batch)
+        sr = self.G(lr, hr_cov)
+        loss = mean_squared_error(sr, hr)
+        self.log("Train MSE", loss, sync_dist=True)
+
+        if (batch_idx + 1) % self.log_every_n_steps == 0:
+            configure_figure(self.G, self.logger, "Train", lr, hr, hr_cov)
+
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        lr, hr, hr_cov = self.unpack_batch(batch)
+        sr = self.G(lr, hr_cov)
+        loss = mean_squared_error(sr, hr)
+        self.log("Validation MSE", loss, sync_dist=True)
+
+        if (batch_idx + 1) % self.validation_log_every_n_steps == 0:
+            configure_figure(self.G, self.logger, "Validation", lr, hr, hr_cov)
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.G.parameters(), lr=self.learning_rate)
+
+    def on_train_epoch_end(self):
+        g_path = f"{self.save_dir}/generator_{self.experiment_name}.pt"
+        g_scripted = torch.jit.script(self.G)
+        g_scripted.save(g_path)
+        self.logger.experiment.log_model("Generator", g_path, overwrite=True)

--- a/ClimatExML/cnn.py
+++ b/ClimatExML/cnn.py
@@ -36,7 +36,7 @@ class CNNTrainer(BaseSuperResolutionTrainer):
 
         self.G = HRStreamGenerator(
             noise=False,
-            filters=64,
+            filters=32,
             fine_dims=hr_dim,
             channels=n_covariates,
             channels_hr_cov=n_hr_covariates,
@@ -44,7 +44,7 @@ class CNNTrainer(BaseSuperResolutionTrainer):
         )
 
     def unpack_batch(self, batch):
-        lr, hr, hr_cov = batch
+        lr, hr, hr_cov = batch[0]
         return lr.float(), hr.float(), hr_cov.float()
 
     def training_step(self, batch, batch_idx):

--- a/ClimatExML/cnn.py
+++ b/ClimatExML/cnn.py
@@ -59,7 +59,7 @@ class CNNTrainer(BaseSuperResolutionTrainer):
         return loss
 
     def validation_step(self, batch, batch_idx):
-        lr, hr, hr_cov = self.unpack_batch(batch)
+        lr, hr, hr_cov = batch
         sr = self.G(lr, hr_cov)
         loss = mean_squared_error(sr, hr)
         self.log("Validation MSE", loss, sync_dist=True)

--- a/ClimatExML/conf/config.yaml
+++ b/ClimatExML/conf/config.yaml
@@ -1,3 +1,5 @@
+# Declare model trainer type, current options: cnn, wgan
+trainer: wgan
 
 hyperparameters:
   # Adam Optimizer

--- a/ClimatExML/train.py
+++ b/ClimatExML/train.py
@@ -42,13 +42,24 @@ def main(cfg: dict):
         num_workers=hardware.num_workers,
     )
 
-    srmodel = CNNTrainer(
-        tracking,
-        hardware,
-        hyperparameters,
-        invariant,
-        log_every_n_steps=tracking.log_every_n_steps,
-    )
+    sr_trainers = {
+        "cnn": CNNTrainer(
+                tracking,
+                hardware,
+                hyperparameters,
+                invariant,
+                log_every_n_steps=tracking.log_every_n_steps,
+            ),
+        "wgan": SuperResolutionWGANGP(
+                tracking,
+                hardware,
+                hyperparameters,
+                invariant,
+                log_every_n_steps=tracking.log_every_n_steps,
+            )
+    }
+
+    srmodel = sr_trainers[cfg.trainer]
 
     trainer = pl.Trainer(
         precision=hardware.precision,

--- a/ClimatExML/train.py
+++ b/ClimatExML/train.py
@@ -1,6 +1,7 @@
 import comet_ml
 import lightning as pl
 from ClimatExML.wgan_gp import SuperResolutionWGANGP
+from ClimatExML.cnn import CNNTrainer
 from ClimatExML.loader import ClimatExLightning
 from ClimatExML.mlclasses import InputVariables, InvariantData
 from lightning.pytorch.loggers import CometLogger
@@ -41,7 +42,7 @@ def main(cfg: dict):
         num_workers=hardware.num_workers,
     )
 
-    srmodel = SuperResolutionWGANGP(
+    srmodel = CNNTrainer(
         tracking,
         hardware,
         hyperparameters,

--- a/ClimatExML/trainer_utils.py
+++ b/ClimatExML/trainer_utils.py
@@ -1,0 +1,67 @@
+from typing import Optional
+import torch
+from torch import Tensor, optim
+import matplotlib.pyplot as plt
+from lightning.pytorch import LightningModule
+from lightning.pytorch.loggers import CometLogger
+
+from ClimatExML.logging_tools import gen_grid_images
+
+
+def go_downhill(lightning_module: LightningModule, loss: Tensor, opt: optim.Optimizer) -> None:
+    """
+    Performs a manual optimization step for manual_optimization=True trainers.
+
+    Args:
+        lightning_module (LightningModule): The model using manual optimization.
+        loss (Tensor): The computed loss.
+        opt (Optimizer): The optimizer to step.
+    """
+    lightning_module.manual_backward(loss)
+    opt.step()
+    opt.zero_grad()
+    lightning_module.untoggle_optimizer(opt)
+
+
+def configure_figure(
+    generator: torch.nn.Module,
+    logger: CometLogger,
+    set_type: str,
+    lr: Tensor,
+    hr: Tensor,
+    hr_cov: Optional[Tensor],
+    use_hr_cov: bool = True,
+    n_examples: int = 3,
+    cmap: str = "viridis",
+) -> None:
+    """
+    Logs side-by-side plots of SR, HR, and inputs for visualization.
+
+    Args:
+        generator (nn.Module): The generator model (e.g., self.G).
+        logger (CometLogger): The experiment logger.
+        set_type (str): One of "Train", "Validation", etc.
+        lr (Tensor): Low-resolution input tensor.
+        hr (Tensor): High-resolution target tensor.
+        hr_cov (Optional[Tensor]): High-res invariant input (or dummy).
+        use_hr_cov (bool): Whether the generator uses HR covariates.
+        n_examples (int): Number of examples to plot.
+        cmap (str): Colormap for the images.
+    """
+    for var in range(hr.shape[1]):
+        fig = plt.figure(figsize=(30, 10))
+        fig = gen_grid_images(
+            var,
+            fig,
+            generator,
+            lr,
+            hr,
+            hr_cov,
+            use_hr_cov,
+            n_examples,
+            cmap=cmap,
+        )
+        logger.experiment.log_figure(
+            figure_name=f"{set_type}_images_{var}", figure=fig, overwrite=True
+        )
+        plt.close(fig)

--- a/ClimatExML/wgan_gp.py
+++ b/ClimatExML/wgan_gp.py
@@ -1,8 +1,19 @@
+import torch
+import torch.nn as nn
+from torchmetrics.functional import mean_absolute_error, mean_squared_error
+from torchmetrics.functional.image import multiscale_structural_similarity_index_measure
+from lightning.pytorch.loggers import CometLogger
+
+from ClimatExML.models import HRStreamGenerator, Critic
+from ClimatExML.trainer_utils import go_downhill, configure_figure, compute_gradient_penalty
+from ClimatExML.base_trainer import BaseSuperResolutionTrainer
+
+
 import os
 import comet_ml
 import lightning as pl
 import torch
-from ClimatExML.models import Generator, HRStreamGenerator, Critic
+from ClimatExML.models import HRStreamGenerator, Critic
 import torch.nn as nn
 from ClimatExML.logging_tools import gen_grid_images
 
@@ -15,13 +26,7 @@ from omegaconf.dictconfig import DictConfig
 import matplotlib.pyplot as plt
 
 
-class SuperResolutionWGANGP(pl.LightningModule):
-    tracking: DictConfig
-    hardware: DictConfig
-    hyperparameters: DictConfig
-    invariant: DictConfig
-    is_noise: bool
-
+class SuperResolutionWGANGP(BaseSuperResolutionTrainer):
     def __init__(
         self,
         tracking,
@@ -32,11 +37,11 @@ class SuperResolutionWGANGP(pl.LightningModule):
     ):
         super().__init__()
         self.save_hyperparameters()
-        self.num_workers = hardware.num_workers
+
         self.log_every_n_steps = tracking.log_every_n_steps
+        self.validation_log_every_n_steps = tracking.validation_log_every_n_steps
         self.save_dir = tracking.save_dir
         self.experiment_name = tracking.experiment_name
-        self.validation_log_every_n_steps = tracking.validation_log_every_n_steps
 
         self.learning_rate = hyperparameters.learning_rate
         self.b1 = hyperparameters.b1
@@ -50,119 +55,50 @@ class SuperResolutionWGANGP(pl.LightningModule):
         self.hr_shape = invariant.hr_shape
         self.hr_invariant_shape = invariant.hr_invariant_shape
 
-        # networks
         n_covariates, lr_dim, _ = self.lr_shape
         n_predictands, hr_dim, _ = self.hr_shape
-
         n_hr_covariates = self.hr_invariant_shape[0]
-        self.G = HRStreamGenerator(
-            self.is_noise, lr_dim, hr_dim, n_covariates, n_hr_covariates, n_predictands
-        )
 
+        self.G = HRStreamGenerator(
+            noise=self.is_noise,
+            filters=lr_dim,
+            fine_dims=hr_dim,
+            channels=n_covariates,
+            channels_hr_cov=n_hr_covariates,
+            n_predictands=n_predictands,
+        )
         self.C = Critic(lr_dim, hr_dim, n_predictands)
         self.automatic_optimization = False
 
-        self.delta_precip_hr = -0.0769779160618782 / 0.3726992905139923
-        self.delta_precip_lr = -0.0795731395483017 / 0.2713610827922821
-
-    def compute_gradient_penalty(self, real_samples, fake_samples):
-        """Calculates the gradient penalty loss for WGAN GP"""
-        current_batch_size = real_samples.size(0)
-        # Calculate interpolation
-
-        # gradient penalty
-        gp_alpha = (
-            torch.rand(current_batch_size, 1, 1, 1, requires_grad=True)
-            .expand_as(real_samples)
-            .to(real_samples)
-        )
-
-        interpolated = gp_alpha * real_samples.data + (1 - gp_alpha) * fake_samples.data
-
-        # Calculate probability of interpolated examples
-        critic_interpolated = self.C(interpolated)
-
-        # self.register_buffer("gp_ones", torch.ones(critic_interpolated.size(), requires_grad=True))
-
-        # Calculate gradients of probabilities with respect to examples
-        gradients = torch.autograd.grad(
-            outputs=critic_interpolated,
-            inputs=interpolated,
-            grad_outputs=torch.ones(critic_interpolated.size(), requires_grad=True).to(
-                real_samples
-            ),
-            create_graph=True,
-            retain_graph=True,
-        )[0]
-
-        # Gradients have shape (batch_size, num_channels, img_width, img_height),
-        # so flatten to easily take norm per example in batch
-        gradients = gradients.view(current_batch_size, -1)
-
-        # Derivatives of the gradient close to 0 can cause problems because of
-        # the square root, so manually calculate norm and add epsilon
-        gradients_norm = torch.sqrt(torch.sum(gradients**2, dim=1) + 1e-12)
-
-        # Return gradient penalty
-        return ((gradients_norm - 1) ** 2).mean()
+    def unpack_batch(self, batch):
+        lr, hr, hr_cov = batch[0]
+        return lr.float(), hr.float(), hr_cov.float()
 
     def losses(self, set_type, hr, sr, mean_sr, mean_hr):
         return {
             f"{set_type} MAE": mean_absolute_error(sr, hr),
             f"{set_type} MSE": mean_squared_error(sr, hr),
-            f"{set_type} MSSIM": multiscale_structural_similarity_index_measure(sr, hr),
+            #f"{set_type} MSSIM": multiscale_structural_similarity_index_measure(sr, hr),
             f"{set_type} Wasserstein Distance": mean_hr - mean_sr,
         }
 
-    def configure_figure(self, set_type, lr, hr, hr_cov, n_examples=3, cmap="viridis"):
-        use_hr_cov = self.hr_invariant_shape is not None
-
-        for var in range(hr.shape[1]):
-            fig = plt.figure(figsize=(30, 10))
-            fig = gen_grid_images(
-                var,
-                fig,
-                self.G,
-                lr,
-                hr,
-                hr_cov,
-                use_hr_cov,
-                n_examples,
-                cmap=cmap,
-            )
-            self.logger.experiment.log_figure(
-                figure_name=f"{set_type}_images_{var}", figure=fig, overwrite=True
-            )
-            plt.close(fig)
-
     def training_step(self, batch, batch_idx):
-
-        # train generator
-        lr, hr, hr_cov = batch[0]
-        lr = lr.float()
-        hr = hr.float()
-        hr_cov = hr_cov.float()
-
+        lr, hr, hr_cov = self.unpack_batch(batch)
         g_opt, c_opt = self.optimizers()
         self.toggle_optimizer(c_opt)
 
         sr = self.G(lr, hr_cov).detach()
-
-        gradient_penalty = self.compute_gradient_penalty(hr, sr)
-        mean_sr = torch.mean(self.C(sr))
-        mean_hr = torch.mean(self.C(hr))
-        loss_c = mean_sr - mean_hr + self.gp_lambda * gradient_penalty
-
-        self.go_downhill(loss_c, c_opt)
+        mean_sr = self.C(sr).mean()
+        mean_hr = self.C(hr).mean()
+        gp = compute_gradient_penalty(self.C, hr, sr)
+        loss_c = mean_sr - mean_hr + self.gp_lambda * gp
+        go_downhill(self, loss_c, c_opt)
 
         if (batch_idx + 1) % self.n_critic == 0:
             self.toggle_optimizer(g_opt)
             sr = self.G(lr, hr_cov)
-            loss_g = -torch.mean(self.C(sr).detach()) + self.alpha * mean_squared_error(
-                sr, hr
-            )
-
-            self.go_downhill(loss_g, g_opt)
+            loss_g = -torch.mean(self.C(sr).detach()) + self.alpha * mean_squared_error(sr, hr)
+            go_downhill(self, loss_g, g_opt)
 
         self.log_dict(
             self.losses("Train", hr, sr.detach(), mean_sr.detach(), mean_hr.detach()),
@@ -170,40 +106,27 @@ class SuperResolutionWGANGP(pl.LightningModule):
         )
 
         if (batch_idx + 1) % self.log_every_n_steps == 0:
-            self.configure_figure(
-                "Train",
-                lr,
-                hr,
-                hr_cov,
-                n_examples=3,
-                cmap="viridis",
-            )
+            configure_figure(self.G, self.logger, "Train", lr, hr, hr_cov)
 
     def validation_step(self, batch, batch_idx):
         lr, hr, hr_cov = batch
-
         sr = self.G(lr, hr_cov).detach()
-        mean_sr = torch.mean(self.C(sr).detach())
-        mean_hr = torch.mean(self.C(hr).detach())
+        mean_sr = self.C(sr).mean()
+        mean_hr = self.C(hr).mean()
         self.log_dict(
             self.losses("Validation", hr, sr, mean_sr, mean_hr),
             sync_dist=True,
         )
 
         if (batch_idx + 1) % self.validation_log_every_n_steps == 0:
-            self.configure_figure(
-                "Validation",
-                lr,
-                hr,
-                hr_cov,
-                n_examples=3,
-                cmap="viridis",
-            )
+            configure_figure(self.G, self.logger, "Validation", lr, hr, hr_cov)
 
-    def on_train_epoch_end(
-        self,
-    ):
-        # save files in working directory for inference
+    def configure_optimizers(self):
+        opt_g = torch.optim.Adam(self.G.parameters(), lr=self.learning_rate, betas=(self.b1, self.b2))
+        opt_c = torch.optim.Adam(self.C.parameters(), lr=self.learning_rate, betas=(self.b1, self.b2))
+        return opt_g, opt_c
+
+    def on_train_epoch_end(self):
         g_path = f"{self.save_dir}/generator_{self.experiment_name}.pt"
         c_path = f"{self.save_dir}/critic_{self.experiment_name}.pt"
 
@@ -214,18 +137,3 @@ class SuperResolutionWGANGP(pl.LightningModule):
 
         self.logger.experiment.log_model("Generator", g_path, overwrite=True)
         self.logger.experiment.log_model("Critic", c_path, overwrite=True)
-
-    def go_downhill(self, loss, opt):
-        self.manual_backward(loss)
-        opt.step()
-        opt.zero_grad()
-        self.untoggle_optimizer(opt)
-
-    def configure_optimizers(self):
-        opt_g = torch.optim.Adam(
-            self.G.parameters(), lr=self.learning_rate, betas=(self.b1, self.b2)
-        )
-        opt_d = torch.optim.Adam(
-            self.C.parameters(), lr=self.learning_rate, betas=(self.b1, self.b2)
-        )
-        return opt_g, opt_d


### PR DESCRIPTION
Resolving Issue #32 

## Summary

This PR begins the modularization of the ClimatExML training architecture by introducing an abstract base trainer class and a new `CNNTrainer` that inherits from it. This allows us to define core training hooks (e.g., `training_step`, `validation_step`, `configure_optimizers`) while decoupling training strategies from model definitions.

## Key Changes

- Added `BaseSuperResolutionTrainer`:
  - Inherits from `pl.LightningModule`
  - Defines abstract methods for key Lightning hooks
  - Serves as the foundation for future trainer types (e.g., GANs, diffusion)

- Implemented `CNNTrainer`:
  - Uses the base trainer structure
  - Implements MSE-based training loop for pure CNN super-resolution

- Refactored `SuperResolutionWGANGP:
  - Now uses the base trainer structure

- Model choice declared at top of the config file

- Detached `filters` from LR input dimension in CNNTrainer:
  - Previously hardcoded as `filters = lr_dim`
  - Now set independently
  - Should ideally be promoted to a configurable hyperparameter in the config YAML
  
  ## Testing
  Successfully trained a cnn model and a wgan model for 10 epochs with standard performance using a 128x128 HR window
