### PR TITLE
Add un-nomralization functionality to the emulator

### DIFF
--- a/ClimatExML/emulator/emulate.py
+++ b/ClimatExML/emulator/emulate.py
@@ -5,7 +5,7 @@ from hydra.utils import instantiate
 from ClimatExML.loader import ClimatExEmulatorDataModule
 from hrstream import HRStreamEmulator
 
-from utils import setup_logger, validate_model_path, run_inference, save_output_to_zarr
+from utils import setup_logger, validate_model_path, run_inference, save_output_to_zarr, un_normalize
 
 
 @hydra.main(config_path="../conf", config_name="config", version_base="1.3")
@@ -48,7 +48,11 @@ def main(cfg):
                             logger=logger)
 
     output_variables = cfg.emulator.output_variables
-    save_output_to_zarr(output=outputs,
+    # Un-normalize
+    output_variables = cfg.emulator.output_variables
+    un_normalized_outputs = un_normalize(outputs, output_variables, model_path)
+
+    save_output_to_zarr(output=un_normalized_outputs,
                         output_variables=output_variables,
                         model_path=model_path,
                         emulation_loader=emulation_loader,


### PR DESCRIPTION
## 🔄 Add Un-normalization Support After Emulator Inference

Contributing to resolution of issue #39 

### Summary

This PR introduces support for **un-normalizing emulator outputs** using variable-specific metadata stored in JSON files created during preprocessing. The un-normalized data is now saved to Zarr with relevant attributes for traceability and reproducibility.

----------

### ✨ Changes Introduced

#### `emulate.py`

-   Added call to `un_normalize()` immediately after `run_inference()`.
    
-   The un-normalized tensor is passed to `save_output_to_zarr()`.
    

#### `utils.py`

-   **`un_normalize()`**:
    
    -   Added function to reverse normalization or standardization using metadata JSON.
        
    -   Includes logging at each step (variable loaded, method applied, fallback if no transform).
        
-   **`load_metadata_json()`**:
    
    -   Helper function to load the appropriate metadata JSON file per variable from the `metadata/` directory associated with the model.
        

#### `save_output_to_zarr()`:

-   Enhanced to:
    
    -   Attach key attributes to each variable:
        
        -   `variable`
            
        -   `units` (from metadata JSON)
            
        -   `preprocessing_hash`
            
        -   `emulator_model` (inferred from `.pt` filename)
            
    -   Log the saved attributes after each variable write.
        

----------

### ✅ Benefits

-   Ensures emulator outputs are returned to their physical units using the exact transformation parameters used during training.
    
-   Helps downstream users validate and interpret model output more accurately.
    
-   Improves traceability with clear attribute metadata (units, hash, model).
   
### 📎 Notes

-   Only `apply_normalize` and `apply_standardize` flags are handled currently (not both at once).
    
-   The JSON metadata file must exist and match the variable name.